### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "grunt-text-replace": "0.3.7"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",
     "gruntcollection"
   ],
-  "readme":"# grunt-mbb-build\r\n\r\n麦包包内部静态文件打包工具，修改于已经消失了的grunt-spm-build。\r\n\r\n## 增加功能\r\n\r\n  样式表图片相对路径转绝对路径\r\n    样式表图片路径md5字符戳\r\n    编译目录中的.handlebars文件\r\n\r\n## 命令\r\n    grunt mbb-build\r\n    grunt hbs\r\n",
+  "readme": "# grunt-mbb-build\r\n\r\n麦包包内部静态文件打包工具，修改于已经消失了的grunt-spm-build。\r\n\r\n## 增加功能\r\n\r\n  样式表图片相对路径转绝对路径\r\n    样式表图片路径md5字符戳\r\n    编译目录中的.handlebars文件\r\n\r\n## 命令\r\n    grunt mbb-build\r\n    grunt hbs\r\n",
   "readmeFilename": "README.md",
   "_id": "grunt-mbb-build@0.1.5",
   "_from": "grunt-mbb-build@~0.1.4"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
